### PR TITLE
feat: add OpenWebRX+ web SDR receiver with digital mode decoders

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,5 +8,5 @@ WIFI_COUNTRY=US
 TAILSCALE_AUTHKEY=
 
 # OpenWebRX+ (optional — create admin user manually if blank)
-# Run on Pi: openwebrx admin adduser admin
+# Run on Pi: docker exec -it openwebrx openwebrx admin adduser admin
 OPENWEBRX_ADMIN_PASSWORD=

--- a/.env.example
+++ b/.env.example
@@ -6,3 +6,7 @@ WIFI_COUNTRY=US
 # Tailscale (optional — authenticate manually on first boot if blank)
 # Generate at: https://login.tailscale.com/admin/settings/keys
 TAILSCALE_AUTHKEY=
+
+# OpenWebRX+ (optional — create admin user manually if blank)
+# Run on Pi: openwebrx admin adduser admin
+OPENWEBRX_ADMIN_PASSWORD=

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,6 +62,7 @@ From [pi-radio-monitoring-research](https://github.com/mihow/pi-radio-monitoring
 
 From this project (pi-sdr, feat/openwebrx branch):
 
+- **WiFi country code (REGDOMAIN)** must be set or the Pi's WiFi radio stays in passive-scan mode and cannot connect. Without `/etc/default/crda` containing `REGDOMAIN=US`, wlan0 is rfkill soft-blocked and NetworkManager reports it as unavailable. The `WIFI_COUNTRY` env var (default `US`) is written during build.
 - **T-Mobile CGNAT path MTU** is ~1424 — silently drops oversized packets without ICMP "too big". TLS handshakes (including Tailscale control plane) hang on first boot. Fix: TCP MSS clamp (`iptables -t mangle -A POSTROUTING -p tcp --tcp-flags SYN,RST SYN -j TCPMSS --clamp-mss-to-pmtu`). Test with `ping -c1 -M do -s 1396 -4 8.8.8.8`.
 - **docker load on SD card** takes >90s for a 1.1GB tar — exceeds systemd's default `TimeoutStartSec=90s`. Set `TimeoutStartSec=300` on services that run `docker load`.
 - **Tailscale reusable keys** are required — one-time keys get consumed before first-boot reboot completes, leaving the device unable to re-authenticate.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,7 +63,7 @@ From [pi-radio-monitoring-research](https://github.com/mihow/pi-radio-monitoring
 From this project (pi-sdr, feat/openwebrx branch):
 
 - **WiFi country code (REGDOMAIN)** must be set or the Pi's WiFi radio stays in passive-scan mode and cannot connect. Without `/etc/default/crda` containing `REGDOMAIN=US`, wlan0 is rfkill soft-blocked and NetworkManager reports it as unavailable. The `WIFI_COUNTRY` env var (default `US`) is written during build.
-- **T-Mobile CGNAT path MTU** is ~1424 — silently drops oversized packets without ICMP "too big". TLS handshakes (including Tailscale control plane) hang on first boot. Fix: TCP MSS clamp (`iptables -t mangle -A POSTROUTING -p tcp --tcp-flags SYN,RST SYN -j TCPMSS --clamp-mss-to-pmtu`). Test with `ping -c1 -M do -s 1396 -4 8.8.8.8`.
+- **T-Mobile CGNAT path MTU** is ~1424 — silently drops oversized packets without ICMP "too big". TLS ClientHello (1581 bytes) gets dropped, so HTTPS to Tailscale control plane and ACME servers hangs. MSS clamp alone is insufficient because TLS handshakes are single TCP segments. Fix: set interface MTU to 1400 (`ip link set eth0 mtu 1400`). Build sets this via networkd-dispatcher script and in NetworkManager connection files. Test with `ping -c1 -M do -s 1396 -4 8.8.8.8`.
 - **docker load on SD card** takes >90s for a 1.1GB tar — exceeds systemd's default `TimeoutStartSec=90s`. Set `TimeoutStartSec=300` on services that run `docker load`.
 - **Tailscale reusable keys** are required — one-time keys get consumed before first-boot reboot completes, leaving the device unable to re-authenticate.
 - **OpenWebRX+ requires Docker** on Trixie — native apt install fails because `python3-csdr` requires Python < 3.12 but Trixie ships 3.13.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,5 +60,15 @@ From [pi-radio-monitoring-research](https://github.com/mihow/pi-radio-monitoring
 - **PipeWire TCP mode** (port 4713) required for audio from Docker containers — socket bind-mount doesn't work
 - **Trixie rtl-sdr 2.0.2** includes V4 support — may not need custom Blog fork compile
 
+From this project (pi-sdr, feat/openwebrx branch):
+
+- **T-Mobile CGNAT path MTU** is ~1424 — silently drops oversized packets without ICMP "too big". TLS handshakes (including Tailscale control plane) hang on first boot. Fix: TCP MSS clamp (`iptables -t mangle -A POSTROUTING -p tcp --tcp-flags SYN,RST SYN -j TCPMSS --clamp-mss-to-pmtu`). Test with `ping -c1 -M do -s 1396 -4 8.8.8.8`.
+- **docker load on SD card** takes >90s for a 1.1GB tar — exceeds systemd's default `TimeoutStartSec=90s`. Set `TimeoutStartSec=300` on services that run `docker load`.
+- **Tailscale reusable keys** are required — one-time keys get consumed before first-boot reboot completes, leaving the device unable to re-authenticate.
+- **OpenWebRX+ requires Docker** on Trixie — native apt install fails because `python3-csdr` requires Python < 3.12 but Trixie ships 3.13.
+- **OpenWebRX+ auto-detects SSL** certs at `/etc/openwebrx/cert.pem` and `/etc/openwebrx/key.pem` — no config change needed beyond placing the files there.
+- **SSH "too many auth failures"** happens when the client has many SSH keys loaded — the server's `MaxAuthTries` is exhausted before password auth is tried. Use `-o PubkeyAuthentication=no` or `ssh-copy-id` to add a specific key.
+- **Docker bridge creation triggers Tailscale rebinding** — `LinkChange: major` events during first boot can race with Tailscale's control plane connection. After a successful connection + reboot, cached state prevents the issue.
+
 ## Downstream projects
 - [pi-radio-station](https://github.com/mihow/pi-radio-station) — full SDR monitoring station with Liquidsoap audio mixing, AirPlay, web dashboard

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ RUN apt-get update && apt-get install -y \
     kpartx \
     udev \
     curl \
+    docker.io \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /build

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # pi-sdr
 
-Minimal Raspberry Pi 5 image builder for Software-Defined Radio. Produces a flashable `.img.xz` with RTL-SDR V4 drivers, SoapySDR, and Tailscale pre-installed. No audio stack, no scanner config — just the SDR foundation.
+Raspberry Pi 5 SDR image builder with a web-based receiver. Produces a flashable `.img.xz` with OpenWebRX+, RTL-SDR V4 drivers, digital mode decoders, and Tailscale. Boot it, open a browser, tune the waterfall.
 
 ## Prerequisites
 
@@ -48,13 +48,56 @@ Pre-built images are available from the [latest release](../../releases/latest).
 | Component | Version | Notes |
 |-----------|---------|-------|
 | Raspberry Pi OS | Trixie arm64 lite | Debian 13, pinned 2025-12-04 |
+| OpenWebRX+ | latest | Web-based SDR receiver with waterfall and decoders |
 | rtl-sdr | 2.0.2 | RTL-SDR Blog V4 support (packaged, no source build) |
 | SoapySDR | 0.8.1 | Universal SDR API |
-| SoapyRTLSDR | 0.3.3 | SoapySDR driver for RTL-SDR |
-| python3-soapysdr | 0.8.1 | `import SoapySDR` works out of the box |
 | Tailscale | latest stable | Remote access without port forwarding |
+| codec2 | — | FreeDV, digital voice codec |
+| direwolf | — | APRS/AX.25 packet decoding |
+| wsjtx | — | FT8, FT4, JT65, WSPR, Q65 weak signal modes |
+| m17-demod | — | M17 digital voice |
+| multimon-ng | — | POCSAG paging, EAS, DTMF, and more |
 
-Also includes: DVB kernel module blacklist, udev rules (from `librtlsdr` package), test scripts at `/usr/local/bin/`.
+Also includes: DVB kernel module blacklist, udev rules, frequency bookmarks for US radio services, test scripts at `/usr/local/bin/`.
+
+## Web UI (OpenWebRX+)
+
+After flashing and booting, OpenWebRX+ starts automatically on port 8073:
+
+- **Local network:** `http://<pi-ip>:8073`
+- **Via Tailscale:** `http://<pi-tailscale-name>:8073`
+
+Anyone on the network can tune and listen. The admin panel (settings, bookmarks) requires login.
+
+### First-time setup
+
+1. Log in to the admin panel at `http://<pi-ip>:8073/settings`
+2. Set your receiver name, location, and GPS coordinates
+3. Adjust RTL-SDR gain for your antenna and environment
+4. Add local repeater frequencies to bookmarks
+
+If you set `OPENWEBRX_ADMIN_PASSWORD` in `.env` before building, the admin user is pre-created. Otherwise create one via SSH:
+
+```bash
+openwebrx admin adduser admin
+```
+
+### Pre-configured band profiles
+
+| Profile | Frequency range | Modulation |
+|---------|----------------|------------|
+| FM Broadcast | 88–108 MHz | WFM |
+| NOAA Weather | 162.4–162.55 MHz | NFM |
+| 2m Ham | 144–148 MHz | NFM |
+| 70cm Ham | 420–450 MHz | NFM |
+| GMRS/FRS | 462–467 MHz | NFM |
+| Air Band | 118–137 MHz | AM |
+| Marine VHF | 156–162 MHz | NFM |
+| APRS | 144.39 MHz | Packet |
+
+### Digital modes
+
+FT8/FT4/WSPR/JT65 (wsjtx), APRS (direwolf), DMR/D-STAR/NXDN/P25 (digiham), M17 (m17-demod), POCSAG/FLEX (multimon-ng), FreeDV (codec2), CW, SSTV, AIS, NAVTEX.
 
 ## Testing with a real dongle (no flashing needed)
 
@@ -103,6 +146,9 @@ WIFI_COUNTRY=US
 
 # Tailscale (optional — authenticate manually on first boot if blank)
 TAILSCALE_AUTHKEY=tskey-auth-...
+
+# OpenWebRX+ admin (optional — create manually if blank)
+OPENWEBRX_ADMIN_PASSWORD=changeme
 ```
 
 Build-time options (env vars passed to `docker compose run`):
@@ -116,10 +162,10 @@ Build-time options (env vars passed to `docker compose run`):
 
 1. Docker container (Ubuntu 24.04) with QEMU user-mode emulation
 2. Downloads pinned Raspberry Pi OS Trixie arm64 lite image (cached after first download)
-3. Expands the root partition by 2 GB
+3. Expands the root partition by 3 GB
 4. Mounts via `kpartx` and chroots with QEMU aarch64
-5. `apt install rtl-sdr soapysdr-tools ...` (no source compilation needed — Trixie's rtl-sdr 2.0.2 includes V4 support)
-6. Installs Tailscale, DVB blacklist, WiFi config, test scripts
+5. `apt install rtl-sdr soapysdr-tools openwebrx ...` (no source compilation)
+6. Installs Tailscale, decoders, DVB blacklist, WiFi config, bookmarks, test scripts
 7. Cleans up and compresses to `.img.xz`
 
 To rebuild, remove the output image and re-run. The downloaded base image is cached:
@@ -144,12 +190,9 @@ GitHub Actions builds and publishes `.img.xz` to Releases on tag push:
 git tag v0.1.0 && git push --tags
 ```
 
-## Downstream projects
+## Related projects
 
-This image is a foundation. Install additional software on top:
-
-- [OpenWebRX+](https://www.openwebrx.de/) — web-based SDR receiver with waterfall
-- [trunk-recorder](https://github.com/robotastic/trunk-recorder) — trunked radio system recorder
-- [rtl_airband](https://github.com/rtl-airband/RTLSDR-Airband) — aviation scanner
 - [signal-logs](https://github.com/mihow/signal-logs) — passive radio monitoring with AI-powered transcription and summarization
 - [pi-radio-station](https://github.com/mihow/pi-radio-station) — full monitoring station with audio mixing
+- [trunk-recorder](https://github.com/robotastic/trunk-recorder) — trunked radio system recorder
+- [OpenWebRX+](https://www.openwebrx.de/) — the web SDR receiver included in this image

--- a/README.md
+++ b/README.md
@@ -138,22 +138,32 @@ These are installed to `/usr/local/bin/` on the Pi image:
 
 ## Configuration
 
-Copy `.env.example` to `.env`:
+Copy `.env.example` to `.env` and fill in what you need. All variables are optional — the image works without any of them, but some features require manual setup on the Pi instead.
 
 ```bash
-# WiFi (optional — leave blank for ethernet only)
+# WiFi (optional)
 WIFI_SSID=MyNetwork
 WIFI_PASSWORD=secret
 WIFI_COUNTRY=US
 
-# Tailscale (optional — authenticate manually on first boot if blank)
+# Tailscale (optional)
 TAILSCALE_AUTHKEY=tskey-auth-...
 
-# OpenWebRX+ admin (optional — create manually if blank)
+# OpenWebRX+ admin (optional)
 OPENWEBRX_ADMIN_PASSWORD=changeme
 ```
 
-Build-time options (env vars passed to `docker compose run`):
+### What happens when variables aren't set
+
+| Variable | If blank | Manual setup |
+|----------|----------|--------------|
+| `WIFI_SSID` | No WiFi configured. Pi only works over ethernet. | SSH in and use `nmcli dev wifi connect <SSID> password <pass>` |
+| `TAILSCALE_AUTHKEY` | Tailscale is installed but not authenticated. No remote access until you log in. | SSH in and run `sudo tailscale up` |
+| `OPENWEBRX_ADMIN_PASSWORD` | OpenWebRX+ works for listening (no login needed) but admin settings panel is locked. | SSH in and run `docker exec -it openwebrx openwebrx admin adduser admin` |
+
+Without WiFi or Tailscale, you'll need ethernet + a monitor/keyboard or use Pi Imager's custom settings to enable SSH and set a password for initial access.
+
+### Build-time options
 
 | Variable | Default | Description |
 |----------|---------|-------------|
@@ -164,7 +174,7 @@ Build-time options (env vars passed to `docker compose run`):
 
 1. Docker container (Ubuntu 24.04) with QEMU user-mode emulation
 2. Downloads pinned Raspberry Pi OS Trixie arm64 lite image (cached after first download)
-3. Expands the root partition by 4 GB
+3. Expands the root partition by 5 GB
 4. Mounts via `kpartx` and chroots with QEMU aarch64
 5. `apt install rtl-sdr soapysdr-tools openwebrx ...` (no source compilation)
 6. Installs Tailscale, decoders, DVB blacklist, WiFi config, bookmarks, test scripts

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Also includes: DVB kernel module blacklist, udev rules, frequency bookmarks for 
 
 ## Web UI (OpenWebRX+)
 
-After flashing and booting, OpenWebRX+ starts automatically on port 8073:
+OpenWebRX+ runs as a Docker container on the Pi (the Bookworm apt packages aren't compatible with Trixie's Python 3.13). On first boot, the container image pulls automatically (~1 GB download). After that, it starts on port 8073:
 
 - **Local network:** `http://<pi-ip>:8073`
 - **Via Tailscale:** `http://<pi-tailscale-name>:8073`
@@ -79,8 +79,10 @@ Anyone on the network can tune and listen. The admin panel (settings, bookmarks)
 If you set `OPENWEBRX_ADMIN_PASSWORD` in `.env` before building, the admin user is pre-created. Otherwise create one via SSH:
 
 ```bash
-openwebrx admin adduser admin
+docker exec -it openwebrx openwebrx admin adduser admin
 ```
+
+Config files live at `/opt/openwebrx/` on the Pi and are volume-mounted into the container.
 
 ### Pre-configured band profiles
 
@@ -162,7 +164,7 @@ Build-time options (env vars passed to `docker compose run`):
 
 1. Docker container (Ubuntu 24.04) with QEMU user-mode emulation
 2. Downloads pinned Raspberry Pi OS Trixie arm64 lite image (cached after first download)
-3. Expands the root partition by 3 GB
+3. Expands the root partition by 4 GB
 4. Mounts via `kpartx` and chroots with QEMU aarch64
 5. `apt install rtl-sdr soapysdr-tools openwebrx ...` (no source compilation)
 6. Installs Tailscale, decoders, DVB blacklist, WiFi config, bookmarks, test scripts

--- a/config/openwebrx/bookmarks.d/aviation.json
+++ b/config/openwebrx/bookmarks.d/aviation.json
@@ -1,0 +1,32 @@
+[
+  {
+    "name": "Aviation Emergency (121.500)",
+    "frequency": 121500000,
+    "modulation": "am"
+  },
+  {
+    "name": "Air-to-Air (122.750)",
+    "frequency": 122750000,
+    "modulation": "am"
+  },
+  {
+    "name": "Helicopter (123.025)",
+    "frequency": 123025000,
+    "modulation": "am"
+  },
+  {
+    "name": "Air-to-Air (123.450)",
+    "frequency": 123450000,
+    "modulation": "am"
+  },
+  {
+    "name": "Military Emergency (243.000)",
+    "frequency": 243000000,
+    "modulation": "am"
+  },
+  {
+    "name": "Flight Service (122.000)",
+    "frequency": 122000000,
+    "modulation": "am"
+  }
+]

--- a/config/openwebrx/bookmarks.d/fm-broadcast.json
+++ b/config/openwebrx/bookmarks.d/fm-broadcast.json
@@ -1,0 +1,57 @@
+[
+  {
+    "name": "FM 88.0",
+    "frequency": 88000000,
+    "modulation": "wfm"
+  },
+  {
+    "name": "FM 90.0",
+    "frequency": 90000000,
+    "modulation": "wfm"
+  },
+  {
+    "name": "FM 92.0",
+    "frequency": 92000000,
+    "modulation": "wfm"
+  },
+  {
+    "name": "FM 94.0",
+    "frequency": 94000000,
+    "modulation": "wfm"
+  },
+  {
+    "name": "FM 96.0",
+    "frequency": 96000000,
+    "modulation": "wfm"
+  },
+  {
+    "name": "FM 98.0",
+    "frequency": 98000000,
+    "modulation": "wfm"
+  },
+  {
+    "name": "FM 100.0",
+    "frequency": 100000000,
+    "modulation": "wfm"
+  },
+  {
+    "name": "FM 102.0",
+    "frequency": 102000000,
+    "modulation": "wfm"
+  },
+  {
+    "name": "FM 104.0",
+    "frequency": 104000000,
+    "modulation": "wfm"
+  },
+  {
+    "name": "FM 106.0",
+    "frequency": 106000000,
+    "modulation": "wfm"
+  },
+  {
+    "name": "FM 108.0",
+    "frequency": 108000000,
+    "modulation": "wfm"
+  }
+]

--- a/config/openwebrx/bookmarks.d/frs.json
+++ b/config/openwebrx/bookmarks.d/frs.json
@@ -1,0 +1,112 @@
+[
+  {
+    "name": "FRS 1",
+    "frequency": 462562500,
+    "modulation": "nfm"
+  },
+  {
+    "name": "FRS 2",
+    "frequency": 462587500,
+    "modulation": "nfm"
+  },
+  {
+    "name": "FRS 3",
+    "frequency": 462612500,
+    "modulation": "nfm"
+  },
+  {
+    "name": "FRS 4",
+    "frequency": 462637500,
+    "modulation": "nfm"
+  },
+  {
+    "name": "FRS 5",
+    "frequency": 462662500,
+    "modulation": "nfm"
+  },
+  {
+    "name": "FRS 6",
+    "frequency": 462687500,
+    "modulation": "nfm"
+  },
+  {
+    "name": "FRS 7",
+    "frequency": 462712500,
+    "modulation": "nfm"
+  },
+  {
+    "name": "FRS 8",
+    "frequency": 467562500,
+    "modulation": "nfm"
+  },
+  {
+    "name": "FRS 9",
+    "frequency": 467587500,
+    "modulation": "nfm"
+  },
+  {
+    "name": "FRS 10",
+    "frequency": 467612500,
+    "modulation": "nfm"
+  },
+  {
+    "name": "FRS 11",
+    "frequency": 467637500,
+    "modulation": "nfm"
+  },
+  {
+    "name": "FRS 12",
+    "frequency": 467662500,
+    "modulation": "nfm"
+  },
+  {
+    "name": "FRS 13",
+    "frequency": 467687500,
+    "modulation": "nfm"
+  },
+  {
+    "name": "FRS 14",
+    "frequency": 467712500,
+    "modulation": "nfm"
+  },
+  {
+    "name": "FRS 15",
+    "frequency": 462550000,
+    "modulation": "nfm"
+  },
+  {
+    "name": "FRS 16",
+    "frequency": 462575000,
+    "modulation": "nfm"
+  },
+  {
+    "name": "FRS 17",
+    "frequency": 462600000,
+    "modulation": "nfm"
+  },
+  {
+    "name": "FRS 18",
+    "frequency": 462625000,
+    "modulation": "nfm"
+  },
+  {
+    "name": "FRS 19",
+    "frequency": 462650000,
+    "modulation": "nfm"
+  },
+  {
+    "name": "FRS 20",
+    "frequency": 462675000,
+    "modulation": "nfm"
+  },
+  {
+    "name": "FRS 21",
+    "frequency": 462700000,
+    "modulation": "nfm"
+  },
+  {
+    "name": "FRS 22",
+    "frequency": 462725000,
+    "modulation": "nfm"
+  }
+]

--- a/config/openwebrx/bookmarks.d/gmrs.json
+++ b/config/openwebrx/bookmarks.d/gmrs.json
@@ -1,0 +1,77 @@
+[
+  {
+    "name": "GMRS 1",
+    "frequency": 462562500,
+    "modulation": "nfm"
+  },
+  {
+    "name": "GMRS 2",
+    "frequency": 462587500,
+    "modulation": "nfm"
+  },
+  {
+    "name": "GMRS 3",
+    "frequency": 462612500,
+    "modulation": "nfm"
+  },
+  {
+    "name": "GMRS 4",
+    "frequency": 462637500,
+    "modulation": "nfm"
+  },
+  {
+    "name": "GMRS 5",
+    "frequency": 462662500,
+    "modulation": "nfm"
+  },
+  {
+    "name": "GMRS 6",
+    "frequency": 462687500,
+    "modulation": "nfm"
+  },
+  {
+    "name": "GMRS 7",
+    "frequency": 462712500,
+    "modulation": "nfm"
+  },
+  {
+    "name": "GMRS 15R (Repeater Output)",
+    "frequency": 462550000,
+    "modulation": "nfm"
+  },
+  {
+    "name": "GMRS 16R (Repeater Output)",
+    "frequency": 462575000,
+    "modulation": "nfm"
+  },
+  {
+    "name": "GMRS 17R (Repeater Output)",
+    "frequency": 462600000,
+    "modulation": "nfm"
+  },
+  {
+    "name": "GMRS 18R (Repeater Output)",
+    "frequency": 462625000,
+    "modulation": "nfm"
+  },
+  {
+    "name": "GMRS 19R (Repeater Output)",
+    "frequency": 462650000,
+    "modulation": "nfm"
+  },
+  {
+    "name": "GMRS 20R (Repeater Output)",
+    "frequency": 462675000,
+    "modulation": "nfm"
+  },
+  {
+    "name": "GMRS 21R (Repeater Output)",
+    "frequency": 462700000,
+    "modulation": "nfm"
+  },
+  {
+    "name": "GMRS 22R (Repeater Output)",
+    "frequency": 462725000,
+    "modulation": "nfm"
+  }
+]

--- a/config/openwebrx/bookmarks.d/ham-2m.json
+++ b/config/openwebrx/bookmarks.d/ham-2m.json
@@ -1,0 +1,27 @@
+[
+  {
+    "name": "144.390 (APRS)",
+    "frequency": 144390000,
+    "modulation": "nfm"
+  },
+  {
+    "name": "146.520 (National Simplex)",
+    "frequency": 146520000,
+    "modulation": "nfm"
+  },
+  {
+    "name": "146.580 (Simplex)",
+    "frequency": 146580000,
+    "modulation": "nfm"
+  },
+  {
+    "name": "147.000 (Repeater)",
+    "frequency": 147000000,
+    "modulation": "nfm"
+  },
+  {
+    "name": "145.050 (Packet)",
+    "frequency": 145050000,
+    "modulation": "nfm"
+  }
+]

--- a/config/openwebrx/bookmarks.d/ham-70cm.json
+++ b/config/openwebrx/bookmarks.d/ham-70cm.json
@@ -1,0 +1,22 @@
+[
+  {
+    "name": "446.000 (National Simplex)",
+    "frequency": 446000000,
+    "modulation": "nfm"
+  },
+  {
+    "name": "446.500 (Simplex)",
+    "frequency": 446500000,
+    "modulation": "nfm"
+  },
+  {
+    "name": "446.100 (Simplex)",
+    "frequency": 446100000,
+    "modulation": "nfm"
+  },
+  {
+    "name": "449.950 (Simplex)",
+    "frequency": 449950000,
+    "modulation": "nfm"
+  }
+]

--- a/config/openwebrx/bookmarks.d/marine-vhf.json
+++ b/config/openwebrx/bookmarks.d/marine-vhf.json
@@ -1,0 +1,27 @@
+[
+  {
+    "name": "Marine VHF 16 (Distress)",
+    "frequency": 156800000,
+    "modulation": "nfm"
+  },
+  {
+    "name": "Marine VHF 9 (Calling)",
+    "frequency": 156450000,
+    "modulation": "nfm"
+  },
+  {
+    "name": "Marine VHF 13 (Bridge-to-Bridge)",
+    "frequency": 156650000,
+    "modulation": "nfm"
+  },
+  {
+    "name": "Marine VHF 6 (Safety)",
+    "frequency": 156300000,
+    "modulation": "nfm"
+  },
+  {
+    "name": "Marine VHF 22A (Coast Guard)",
+    "frequency": 157100000,
+    "modulation": "nfm"
+  }
+]

--- a/config/openwebrx/bookmarks.d/murs.json
+++ b/config/openwebrx/bookmarks.d/murs.json
@@ -1,0 +1,27 @@
+[
+  {
+    "name": "MURS 1",
+    "frequency": 151820000,
+    "modulation": "nfm"
+  },
+  {
+    "name": "MURS 2",
+    "frequency": 151880000,
+    "modulation": "nfm"
+  },
+  {
+    "name": "MURS 3",
+    "frequency": 151940000,
+    "modulation": "nfm"
+  },
+  {
+    "name": "MURS 4",
+    "frequency": 154570000,
+    "modulation": "nfm"
+  },
+  {
+    "name": "MURS 5",
+    "frequency": 154600000,
+    "modulation": "nfm"
+  }
+]

--- a/config/openwebrx/bookmarks.d/noaa-weather.json
+++ b/config/openwebrx/bookmarks.d/noaa-weather.json
@@ -1,0 +1,37 @@
+[
+  {
+    "name": "NOAA Weather Radio 1",
+    "frequency": 162400000,
+    "modulation": "nfm"
+  },
+  {
+    "name": "NOAA Weather Radio 2",
+    "frequency": 162425000,
+    "modulation": "nfm"
+  },
+  {
+    "name": "NOAA Weather Radio 3",
+    "frequency": 162450000,
+    "modulation": "nfm"
+  },
+  {
+    "name": "NOAA Weather Radio 4",
+    "frequency": 162475000,
+    "modulation": "nfm"
+  },
+  {
+    "name": "NOAA Weather Radio 5",
+    "frequency": 162500000,
+    "modulation": "nfm"
+  },
+  {
+    "name": "NOAA Weather Radio 6",
+    "frequency": 162525000,
+    "modulation": "nfm"
+  },
+  {
+    "name": "NOAA Weather Radio 7",
+    "frequency": 162550000,
+    "modulation": "nfm"
+  }
+]

--- a/config/openwebrx/openwebrx.conf
+++ b/config/openwebrx/openwebrx.conf
@@ -6,6 +6,8 @@ log_level = INFO
 [web]
 port = 8073
 ipv6 = true
+ssl_certificate = /etc/openwebrx/cert.pem
+ssl_key = /etc/openwebrx/key.pem
 
 [aprs]
 symbols_path = /usr/share/aprs-symbols/png

--- a/config/openwebrx/openwebrx.conf
+++ b/config/openwebrx/openwebrx.conf
@@ -1,0 +1,11 @@
+[core]
+data_directory = /var/lib/openwebrx
+temporary_directory = /tmp
+log_level = INFO
+
+[web]
+port = 8073
+ipv6 = true
+
+[aprs]
+symbols_path = /usr/share/aprs-symbols/png

--- a/config/openwebrx/settings.json
+++ b/config/openwebrx/settings.json
@@ -47,7 +47,7 @@
                 },
                 "airband": {
                     "name": "Air Band",
-                    "center_freq": 127000000,
+                    "center_freq": 122500000,
                     "samp_rate": 2400000,
                     "start_freq": 121500000,
                     "start_mod": "am",

--- a/config/openwebrx/settings.json
+++ b/config/openwebrx/settings.json
@@ -1,0 +1,104 @@
+{
+    "version": 7,
+    "sdrs": {
+        "rtlsdr": {
+            "name": "RTL-SDR Blog V4",
+            "type": "rtl_sdr",
+            "profiles": {
+                "fm-broadcast": {
+                    "name": "FM Broadcast",
+                    "center_freq": 97500000,
+                    "samp_rate": 2400000,
+                    "start_freq": 97500000,
+                    "start_mod": "wfm",
+                    "rf_gain": 29
+                },
+                "noaa-weather": {
+                    "name": "NOAA Weather",
+                    "center_freq": 162475000,
+                    "samp_rate": 2400000,
+                    "start_freq": 162400000,
+                    "start_mod": "nfm",
+                    "rf_gain": 29
+                },
+                "2m": {
+                    "name": "2m Ham",
+                    "center_freq": 146000000,
+                    "samp_rate": 2400000,
+                    "start_freq": 146520000,
+                    "start_mod": "nfm",
+                    "rf_gain": 29
+                },
+                "70cm": {
+                    "name": "70cm Ham",
+                    "center_freq": 446000000,
+                    "samp_rate": 2400000,
+                    "start_freq": 446000000,
+                    "start_mod": "nfm",
+                    "rf_gain": 29
+                },
+                "gmrs": {
+                    "name": "GMRS/FRS",
+                    "center_freq": 462562500,
+                    "samp_rate": 2400000,
+                    "start_freq": 462562500,
+                    "start_mod": "nfm",
+                    "rf_gain": 29
+                },
+                "airband": {
+                    "name": "Air Band",
+                    "center_freq": 127000000,
+                    "samp_rate": 2400000,
+                    "start_freq": 121500000,
+                    "start_mod": "am",
+                    "rf_gain": 29
+                },
+                "marine": {
+                    "name": "Marine VHF",
+                    "center_freq": 157000000,
+                    "samp_rate": 2400000,
+                    "start_freq": 156800000,
+                    "start_mod": "nfm",
+                    "rf_gain": 29
+                },
+                "aprs": {
+                    "name": "APRS",
+                    "center_freq": 144500000,
+                    "samp_rate": 2400000,
+                    "start_freq": 144390000,
+                    "start_mod": "packet",
+                    "rf_gain": 29
+                }
+            }
+        }
+    },
+    "receiver_name": "pi-sdr",
+    "receiver_location": "",
+    "receiver_asl": 0,
+    "receiver_admin": "",
+    "receiver_gps": {
+        "lat": 0,
+        "lon": 0
+    },
+    "max_clients": 10,
+    "waterfall_scheme": "GoogleTurboWaterfall",
+    "fft_fps": 9,
+    "fft_size": 4096,
+    "fft_voverlap_factor": 0.3,
+    "waterfall_levels": {
+        "min": -88.0,
+        "max": -20.0
+    },
+    "audio_compression": "adpcm",
+    "fft_compression": "adpcm",
+    "squelch_auto_margin": 10,
+    "digital_voice_dmr_id_lookup": true,
+    "digital_voice_nxdn_id_lookup": true,
+    "decoding_queue_workers": 2,
+    "decoding_queue_length": 10,
+    "wsjt_decoding_depth": 3,
+    "js8_enabled_profiles": ["normal", "slow"],
+    "fst4_enabled_intervals": [15, 30],
+    "fst4w_enabled_intervals": [120, 300],
+    "q65_enabled_combinations": ["A30", "E120"]
+}

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,0 +1,45 @@
+services:
+  # Tailscale sidecar — provides network identity, HTTPS cert, and SSH
+  tailscale:
+    image: tailscale/tailscale:latest
+    hostname: pi-sdr-test
+    container_name: pi-sdr-tailscale
+    cap_add:
+      - NET_ADMIN
+      - SYS_MODULE
+    environment:
+      - TS_AUTHKEY=${TAILSCALE_AUTHKEY}
+      - TS_HOSTNAME=pi-sdr-test
+      - TS_STATE_DIR=/var/lib/tailscale
+      - TS_USERSPACE=false
+    volumes:
+      - ts-state:/var/lib/tailscale
+      - owrx-etc:/owrx-etc
+      - ./scripts/test-entrypoint.sh:/entrypoint-custom.sh:ro
+      - ./config/openwebrx:/config-src:ro
+    entrypoint: ["/bin/sh", "/entrypoint-custom.sh"]
+    devices:
+      - /dev/net/tun:/dev/net/tun
+
+  # OpenWebRX+ — shares Tailscale network, uses its HTTPS cert
+  openwebrx:
+    image: slechev/openwebrxplus-softmbe:latest
+    container_name: pi-sdr-openwebrx
+    network_mode: service:tailscale
+    depends_on:
+      tailscale:
+        condition: service_started
+    devices:
+      - /dev/bus/usb:/dev/bus/usb
+    volumes:
+      - owrx-etc:/etc/openwebrx
+      - ./config/openwebrx/settings.json:/var/lib/openwebrx/settings.json
+    environment:
+      - OPENWEBRX_ADMIN_USER=admin
+      - OPENWEBRX_ADMIN_PASSWORD=${OPENWEBRX_ADMIN_PASSWORD:-picketfencing}
+    tmpfs:
+      - /tmp
+
+volumes:
+  ts-state:
+  owrx-etc:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,3 +26,4 @@ services:
       - ./scripts:/build/scripts
       - ./config:/build/config
       - ./test-scripts:/build/test-scripts
+      - /var/run/docker.sock:/var/run/docker.sock

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,7 @@ services:
       - WIFI_SSID
       - WIFI_PASSWORD
       - WIFI_COUNTRY
+      - OPENWEBRX_ADMIN_PASSWORD
     volumes:
       - ./data:/build/data
       - ./scripts:/build/scripts

--- a/docs/NEXT_SESSION_PROMPT.md
+++ b/docs/NEXT_SESSION_PROMPT.md
@@ -42,23 +42,28 @@ Developed a fast patching approach — mount the raw .img via kpartx in a Docker
 - `feat/openwebrx` — OpenWebRX+ integration, PR #1 open
 
 ### Built images in data/
-- `data/pi-sdr-base.img` (7.8 GB) — latest build with offline OpenWebRX+, patched with WiFi/Tailscale/SSH/hostname
-- `data/pi-sdr-base.img.xz` (1.2 GB) — compressed version (pre-patch, missing WiFi/Tailscale/SSH)
+- Full rebuild in progress (COMPRESS=false) with SSH + SSL changes baked in
+- Previous image deleted — was built before SSH/SSL fixes
 
-### Pi hardware test in progress
-- First flash (old image, one-time Tailscale key) — Pi registered on Tailscale but SSH never worked (connection refused). Tailscale link was unreachable via ping.
-- User is reflashing with the new patched image (has reusable Tailscale key, SSH enabled, WiFi, offline OpenWebRX+)
-- RTL-SDR Blog V4 dongle available for testing
+### Docker E2E test validated
+- Tailscale auth, HTTPS cert (Let's Encrypt), SSH with password, OpenWebRX+ waterfall + audio all working
+- Test compose: `docker-compose.test.yml` (Tailscale sidecar + OpenWebRX+ sharing network)
+- HTTPS cert needs retry on first boot — ACME auth can lag on new hostnames (entrypoint retries 3x)
+
+### Stale Tailscale nodes to clean up
+- Delete from https://login.tailscale.com/admin/machines:
+  - pi-sdr-test, pi-sdr-test-1, pi-sdr-test-2, pi-sdr-test-3 (test containers)
+  - pi-sdr (100.85.90.10, old Pi attempt)
 
 ## What needs to happen next
 
 ### Immediate
-1. **Test the reflashed Pi** — verify SSH, Tailscale, OpenWebRX+ container starts, web UI works with dongle
-2. **Debug Tailscale connectivity** if it still can't establish a tunnel — may need to check firewall/NAT settings
-3. **Merge PR #1** once Pi test passes
+1. **Wait for rebuild to finish** — verify SSH and SSL are baked in
+2. **E2E test the new image** in Docker before flashing
+3. **Flash to Pi** and verify first-boot: SSH, Tailscale, OpenWebRX+, audio
+4. **Merge PR #1** once Pi test passes
 
 ### Build improvements to add
-- Bake hostname, SSH, and default user into `build-image.sh` (currently requires patching)
 - Add a `scripts/patch-image.sh` script to make the manual patching workflow reusable
 - Consider whether the `COMPRESS` env var should default to `false` for dev and only compress in CI
 

--- a/docs/NEXT_SESSION_PROMPT.md
+++ b/docs/NEXT_SESSION_PROMPT.md
@@ -1,100 +1,122 @@
-# pi-sdr — Implementation Planning Prompt
+# pi-sdr — Next Session Context
 
-## Context
+## What was accomplished
 
-This is a new, clean repo for building minimal Raspberry Pi 5 SDR images. It's a stripped-down version of [pi-radio-monitoring-research](https://github.com/mihow/pi-radio-monitoring-research) — SDR drivers + Tailscale only, no audio stack.
+Built a complete Raspberry Pi 5 SDR image builder with OpenWebRX+ web receiver. The system is Docker-based, cross-compiles for arm64 via QEMU, and produces a flashable `.img.xz`.
 
-The prior repo validated the Docker/QEMU image build pipeline with Bookworm. This project moves to **Trixie** and simplifies: Trixie's `rtl-sdr` 2.0.2 package includes V4 support, so we may not need the custom Blog fork compile.
+### v0.1.0 released (base image, no OpenWebRX+)
+- RTL-SDR V4 validated with Trixie's packaged rtl-sdr 2.0.2 (no source compile needed)
+- SoapySDR + Python bindings
+- Tailscale with optional first-boot auth
+- WiFi via NetworkManager keyfile
+- DVB blacklist, test scripts (check-sdr.sh, tune.sh, scan.sh)
+- GitHub Release: https://github.com/mihow/pi-sdr/releases/tag/v0.1.0
 
-## Goal
+### feat/openwebrx branch (PR #1)
+- OpenWebRX+ runs as Docker container (`slechev/openwebrxplus-softmbe`) — native apt install fails because Bookworm's `python3-csdr` requires Python < 3.12 but Trixie ships 3.13
+- Docker CE installed in the Pi image via apt
+- OpenWebRX+ Docker image (1.1 GB) pre-saved into Pi filesystem for offline first boot
+- 8 RTL-SDR V4 band profiles: FM Broadcast, NOAA Weather, 2m Ham, 70cm Ham, GMRS/FRS, Air Band, Marine VHF, APRS
+- 9 frequency bookmark files (public US FCC/ITU allocations)
+- Auto HTTPS cert generation via Tailscale on first boot (browsers require HTTPS for web audio)
+- Admin user: admin / picketfencing
+- PR: https://github.com/mihow/pi-sdr/pull/1
 
-Build a working Docker-based image builder that produces a flashable `.img.xz` for Raspberry Pi 5 with:
-- RTL-SDR V4 drivers (test Trixie's packaged rtl-sdr 2.0.2 first, fall back to Blog fork if needed)
-- SoapySDR + SoapyRTLSDR + Python 3 bindings
-- Tailscale (pre-installed, optional first-boot auth via env var)
-- WiFi config via .env
-- DVB kernel module blacklist
-- Test scripts: `test-with-usb.sh` (Docker chroot with USB passthrough), `tune.sh` (tune to freq, record IQ), basic connectivity check
-- Compressed `.img.xz` output
-- GitHub Actions workflow to build + publish to Releases on tag push
+### Validated
+- OpenWebRX+ v1.2.96 running on beast with V4 dongle — waterfall + audio working via HTTPS + Tailscale cert
+- All 8 band profiles working, all digital modes available in UI
+- Audio confirmed working in Firefox (Chrome had issues — possibly a plugin conflict on user's machine)
+- Tailscale container test: `pi-sdr-test` got its own Tailscale identity, generated a real cert, audio worked at `https://pi-sdr-test.wirehair-yo.ts.net:8073`
 
-## Key decisions to validate
+### Image patching workflow
+Developed a fast patching approach — mount the raw .img via kpartx in a Docker container and write files directly. No full rebuild needed for WiFi, Tailscale key, SSH, hostname changes. Used this to patch:
+- WiFi: ShinyObject / doingeasy
+- Tailscale: reusable key
+- SSH: pi / picketfencing
+- Hostname: pi-sdr
 
-1. **Does Trixie's packaged rtl-sdr 2.0.2 work with RTL-SDR Blog V4?**
-   - Test: `apt install rtl-sdr` in a Trixie chroot, then `rtl_test -t` with a V4 dongle
-   - If yes: skip the custom compile entirely, massive simplification
-   - If no: compile the Blog fork like before
+## Current state
 
-2. **Does Trixie's packaged SoapySDR work with the packaged rtl-sdr?**
-   - Test: `apt install soapysdr-module-rtlsdr soapysdr-tools python3-soapysdr`
-   - Verify: `SoapySDRUtil --find` detects the dongle, `python3 -c "import SoapySDR"` works
+### Branches
+- `main` — v0.1.0 base image (no OpenWebRX+)
+- `feat/openwebrx` — OpenWebRX+ integration, PR #1 open
 
-3. **Pin a Trixie image date**
-   - Find the latest Pi OS Trixie lite arm64 image URL at raspberrypi.com
-   - Pin it in build-image.sh like we did with Bookworm (2025-05-13)
+### Built images in data/
+- `data/pi-sdr-base.img` (7.8 GB) — latest build with offline OpenWebRX+, patched with WiFi/Tailscale/SSH/hostname
+- `data/pi-sdr-base.img.xz` (1.2 GB) — compressed version (pre-patch, missing WiFi/Tailscale/SSH)
 
-## What to reuse from pi-radio-monitoring-research
+### Pi hardware test in progress
+- First flash (old image, one-time Tailscale key) — Pi registered on Tailscale but SSH never worked (connection refused). Tailscale link was unreachable via ping.
+- User is reflashing with the new patched image (has reusable Tailscale key, SSH enabled, WiFi, offline OpenWebRX+)
+- RTL-SDR Blog V4 dongle available for testing
 
-Copy and adapt (don't copy verbatim — simplify for Trixie):
-- `Dockerfile` — build container with host tools (qemu, parted, kpartx)
-- `docker-compose.yml` — binfmt registration + build service
-- `scripts/build-image.sh` — download, resize, mount, chroot, unmount
-- `scripts/provision.sh` — SIMPLIFIED: just apt install + Tailscale + blacklist, no cmake builds if packaged versions work
-- `scripts/test-with-usb.sh` — Docker chroot with USB passthrough
-- `config/system/blacklist-sdr.conf` — DVB module blacklist
+## What needs to happen next
 
-DO NOT copy:
-- Anything audio-related (PipeWire, WirePlumber, shairport-sync, duck-daemon, espeak-ng)
-- rtl_airband config and service
-- Audio test scripts
-- WirePlumber config files
+### Immediate
+1. **Test the reflashed Pi** — verify SSH, Tailscale, OpenWebRX+ container starts, web UI works with dongle
+2. **Debug Tailscale connectivity** if it still can't establish a tunnel — may need to check firewall/NAT settings
+3. **Merge PR #1** once Pi test passes
 
-## New things to add
+### Build improvements to add
+- Bake hostname, SSH, and default user into `build-image.sh` (currently requires patching)
+- Add a `scripts/patch-image.sh` script to make the manual patching workflow reusable
+- Consider whether the `COMPRESS` env var should default to `false` for dev and only compress in CI
 
-- `.env.example` with documented variables
-- `test-scripts/tune.sh` — tune to a frequency, record IQ samples, print signal info
-- `test-scripts/scan.sh` — quick scan across a frequency range, report active signals
-- GitHub Actions workflow (`.github/workflows/build.yml`) for CI/CD
-- Proper `.gitignore` (data/, *.img, *.img.xz)
+### Known issues
+- `test-with-usb.sh` Docker re-exec mangles complex shell commands (`bash -c "..."`) — works fine for single commands
+- Chrome audio issue on user's machine (works in Firefox, works in headless Chrome) — likely a browser plugin conflict
+- The `.img.xz` doesn't include patches — need to recompress after patching, or always flash from raw `.img`
+- GitHub Actions `docker pull --platform linux/arm64` for the pre-save step needs the Docker socket mounted — verify this works in CI
 
-## Build pipeline (simplified for Trixie)
+## Key technical decisions
 
-1. Download Pi OS Trixie arm64 lite
-2. Resize image (+2GB — less space needed without audio stack)
-3. Loop mount via kpartx
-4. Chroot with QEMU user-mode
-5. `apt update && apt install rtl-sdr soapysdr-tools soapysdr-module-rtlsdr python3-soapysdr`
-6. If V4 doesn't work with packaged rtl-sdr: compile Blog fork
-7. Install Tailscale from official repo
-8. Deploy blacklist, WiFi config, test scripts
-9. Cleanup, unmount, compress to .img.xz
+| Decision | Rationale |
+|----------|-----------|
+| Trixie not Bookworm | Latest Pi OS, rtl-sdr 2.0.2 with V4 support in apt |
+| OpenWebRX+ via Docker not apt | python3-csdr needs Python < 3.12, Trixie has 3.13 |
+| Pre-save Docker image in Pi filesystem | Offline first boot, no 1GB download needed |
+| HTTPS via Tailscale cert | Browsers block AudioContext on HTTP (no sound without HTTPS) |
+| Reusable Tailscale keys | One-time keys get consumed before first-boot reboot completes |
+| kpartx not losetup -P | Docker doesn't create /dev/loopXpN partition devices |
 
-## Test plan
+## Credentials (in .env, gitignored)
 
-- [ ] Build completes without errors
-- [ ] Validation checks pass (rtl_test, SoapySDRUtil, python3 import)
-- [ ] `test-with-usb.sh` detects a real V4 dongle
-- [ ] `tune.sh` tunes to a known frequency and captures IQ
-- [ ] Tailscale connects on first boot (if auth key provided)
-- [ ] WiFi connects on first boot (if credentials provided)
-- [ ] Image flashes and boots on a real Pi 5
-- [ ] `.img.xz` is < 1GB compressed
+- WiFi: ShinyObject / doingeasy
+- SSH: pi / picketfencing
+- OpenWebRX admin: admin / picketfencing
+- Tailscale key: tskey-auth-k4eaQAY5cM11CNTRL-ERhu1rdh7yMzMfaueGHCxMkzwUoEQjpg1 (reusable)
 
-## Hardware available
+## File structure
 
-A real RTL-SDR Blog V4 dongle is plugged into the dev machine. This means we can:
-- Test `rtl_test -t` inside the Docker chroot with USB passthrough
-- Verify whether Trixie's packaged rtl-sdr 2.0.2 works with the V4
-- Test SoapySDR device detection with real hardware
-- Tune to actual frequencies and verify signal reception
-- Run `test-with-usb.sh` for real validation, not just binary checks
-
-This is the first time we have hardware in the loop — prioritize live testing over mock validation.
+```
+pi-sdr/
+├── Dockerfile                          # Build container (Ubuntu 24.04 + qemu + docker.io)
+├── docker-compose.yml                  # binfmt + build service (mounts Docker socket)
+├── .env / .env.example                 # Runtime config (WiFi, Tailscale, OpenWebRX admin)
+├── scripts/
+│   ├── build-image.sh                  # Download, resize, mount, chroot, pre-pull Docker image, compress
+│   ├── provision.sh                    # In-chroot: apt install, Docker CE, OpenWebRX config, Tailscale
+│   ├── check-sdr.sh                    # Device/driver check script
+│   └── test-with-usb.sh               # Docker-wrapped chroot with USB passthrough
+├── config/
+│   ├── system/blacklist-sdr.conf       # DVB kernel module blacklist
+│   └── openwebrx/
+│       ├── openwebrx.conf              # Core config
+│       ├── settings.json               # SDR profiles (8 bands)
+│       └── bookmarks.d/*.json          # 9 bookmark files
+├── test-scripts/                       # Deployed to /usr/local/bin/ on Pi
+│   ├── tune.sh, scan.sh, check-sdr.sh
+├── .github/workflows/build.yml        # CI: shellcheck + build + release on tag push
+├── docs/
+│   ├── NEXT_SESSION_PROMPT.md          # This file
+│   └── superpowers/plans/              # Implementation plans
+└── data/                               # Build output (gitignored)
+```
 
 ## References
 
-- Prior repo: https://github.com/mihow/pi-radio-monitoring-research
-- RTL-SDR Blog V4 info: https://www.rtl-sdr.com/v4/
-- Trixie Pi OS images: https://downloads.raspberrypi.com/raspios_lite_arm64/images/
-- Trixie rtl-sdr package: https://packages.debian.org/trixie/rtl-sdr
-- SoapySDR Trixie: https://packages.debian.org/trixie/soapysdr-tools
+- Prior repo: /home/michael/Projects/Radio/pi-radio-monitor-research/
+- OpenWebRX+ on middle-earth: v1.2.94, apt from luarvique.github.io/ppa, running on port 8073
+- OpenWebRX+ Docker images: slechev/openwebrxplus-softmbe (arm64 + amd64)
+- Tailscale admin: https://login.tailscale.com/admin
+- RTL-SDR Blog V4: 0bda:2838, R828D tuner, 29 gain values (0.0–49.6 dB)

--- a/scripts/build-image.sh
+++ b/scripts/build-image.sh
@@ -268,6 +268,13 @@ if [[ -L "${MOUNT_DIR}/etc/resolv.conf" ]]; then
 fi
 cp /etc/resolv.conf "${MOUNT_DIR}/etc/resolv.conf"
 
+# --- Set hostname ---
+echo ""
+echo "=== Set hostname ==="
+echo "pi-sdr" > "${MOUNT_DIR}/etc/hostname"
+sed -i 's/127\.0\.1\.1.*/127.0.1.1\tpi-sdr/' "${MOUNT_DIR}/etc/hosts"
+echo "  Hostname set to pi-sdr"
+
 # --- Enable SSH ---
 echo ""
 echo "=== Enable SSH ==="

--- a/scripts/build-image.sh
+++ b/scripts/build-image.sh
@@ -26,7 +26,7 @@ IMAGE_DATE="2025-12-04"
 IMAGE_NAME="${IMAGE_DATE}-raspios-trixie-arm64-lite"
 IMAGE_URL="https://downloads.raspberrypi.com/raspios_lite_arm64/images/raspios_lite_arm64-${IMAGE_DATE}/${IMAGE_NAME}.img.xz"
 
-EXPAND_GB=4
+EXPAND_GB=5
 COMPRESS="${COMPRESS:-true}"
 
 BUILD_DIR="/build"
@@ -220,6 +220,16 @@ fi
 if [[ -d "${BUILD_DIR}/test-scripts" ]]; then
     cp -r "${BUILD_DIR}/test-scripts/" "${MOUNT_DIR}/opt/provision/test-scripts/"
 fi
+
+# --- Pre-pull OpenWebRX+ Docker image for offline first boot ---
+echo ""
+echo "=== Pre-pull OpenWebRX+ Docker image (arm64) ==="
+OWRX_IMAGE="slechev/openwebrxplus-softmbe:latest"
+mkdir -p "${MOUNT_DIR}/opt/openwebrx"
+docker pull --platform linux/arm64 "$OWRX_IMAGE"
+echo "Saving image to ${MOUNT_DIR}/opt/openwebrx/image.tar ..."
+docker save "$OWRX_IMAGE" > "${MOUNT_DIR}/opt/openwebrx/image.tar"
+echo "Saved ($(du -sh "${MOUNT_DIR}/opt/openwebrx/image.tar" | cut -f1))"
 
 # --- Disable ld.so.preload ---
 echo ""

--- a/scripts/build-image.sh
+++ b/scripts/build-image.sh
@@ -227,9 +227,9 @@ echo "=== Pre-pull OpenWebRX+ Docker image (arm64) ==="
 OWRX_IMAGE="slechev/openwebrxplus-softmbe:latest"
 mkdir -p "${MOUNT_DIR}/opt/openwebrx"
 docker pull --platform linux/arm64 "$OWRX_IMAGE"
-echo "Saving image to ${MOUNT_DIR}/opt/openwebrx/image.tar ..."
-docker save "$OWRX_IMAGE" > "${MOUNT_DIR}/opt/openwebrx/image.tar"
-echo "Saved ($(du -sh "${MOUNT_DIR}/opt/openwebrx/image.tar" | cut -f1))"
+echo "Saving image to ${MOUNT_DIR}/opt/openwebrx/openwebrxplus-softmbe-arm64.tar ..."
+docker save "$OWRX_IMAGE" > "${MOUNT_DIR}/opt/openwebrx/openwebrxplus-softmbe-arm64.tar"
+echo "Saved ($(du -sh "${MOUNT_DIR}/opt/openwebrx/openwebrxplus-softmbe-arm64.tar" | cut -f1))"
 
 # --- Disable ld.so.preload ---
 echo ""

--- a/scripts/build-image.sh
+++ b/scripts/build-image.sh
@@ -335,6 +335,7 @@ autoconnect=true
 [wifi]
 mode=infrastructure
 ssid=${WIFI_SSID}
+mtu=1400
 
 [wifi-security]
 auth-alg=open

--- a/scripts/build-image.sh
+++ b/scripts/build-image.sh
@@ -26,7 +26,7 @@ IMAGE_DATE="2025-12-04"
 IMAGE_NAME="${IMAGE_DATE}-raspios-trixie-arm64-lite"
 IMAGE_URL="https://downloads.raspberrypi.com/raspios_lite_arm64/images/raspios_lite_arm64-${IMAGE_DATE}/${IMAGE_NAME}.img.xz"
 
-EXPAND_GB=2
+EXPAND_GB=3
 COMPRESS="${COMPRESS:-true}"
 
 BUILD_DIR="/build"
@@ -42,6 +42,7 @@ TAILSCALE_AUTHKEY="${TAILSCALE_AUTHKEY:-}"
 WIFI_SSID="${WIFI_SSID:-}"
 WIFI_PASSWORD="${WIFI_PASSWORD:-}"
 WIFI_COUNTRY="${WIFI_COUNTRY:-US}"
+OPENWEBRX_ADMIN_PASSWORD="${OPENWEBRX_ADMIN_PASSWORD:-}"
 
 # Track state for cleanup
 LOOP_DEV=""
@@ -294,6 +295,7 @@ CHROOT_ENV=(
     "PATH=/usr/sbin:/usr/bin:/sbin:/bin"
 )
 [[ -n "$TAILSCALE_AUTHKEY" ]] && CHROOT_ENV+=("TAILSCALE_AUTHKEY=${TAILSCALE_AUTHKEY}")
+[[ -n "${OPENWEBRX_ADMIN_PASSWORD:-}" ]] && CHROOT_ENV+=("OPENWEBRX_ADMIN_PASSWORD=${OPENWEBRX_ADMIN_PASSWORD}")
 
 # --- Run provision.sh in chroot ---
 echo ""

--- a/scripts/build-image.sh
+++ b/scripts/build-image.sh
@@ -268,6 +268,22 @@ if [[ -L "${MOUNT_DIR}/etc/resolv.conf" ]]; then
 fi
 cp /etc/resolv.conf "${MOUNT_DIR}/etc/resolv.conf"
 
+# --- Enable SSH ---
+echo ""
+echo "=== Enable SSH ==="
+touch "${MOUNT_DIR}/boot/firmware/ssh"
+echo "  Created /boot/firmware/ssh"
+
+# --- Set pi user password ---
+echo ""
+echo "=== Set pi user password ==="
+# Generate hashed password and write to userconf.txt for first-boot user setup.
+# Pi OS Trixie uses this file to set up the default user on first boot.
+PI_PASSWORD="picketfencing"
+PI_HASH=$(openssl passwd -6 "$PI_PASSWORD")
+echo "pi:${PI_HASH}" > "${MOUNT_DIR}/boot/firmware/userconf.txt"
+echo "  Written to /boot/firmware/userconf.txt (pi:picketfencing)"
+
 # --- WiFi configuration ---
 if [[ -n "$WIFI_SSID" ]]; then
     echo ""

--- a/scripts/build-image.sh
+++ b/scripts/build-image.sh
@@ -291,6 +291,16 @@ PI_HASH=$(openssl passwd -6 "$PI_PASSWORD")
 echo "pi:${PI_HASH}" > "${MOUNT_DIR}/boot/firmware/userconf.txt"
 echo "  Written to /boot/firmware/userconf.txt (pi:picketfencing)"
 
+# --- WiFi regulatory domain ---
+# Without a country code, the Pi WiFi radio stays in passive-scan mode
+# and cannot connect to any network.
+echo ""
+echo "=== Set WiFi country: $WIFI_COUNTRY ==="
+cat > "${MOUNT_DIR}/etc/default/crda" << EOF
+REGDOMAIN=${WIFI_COUNTRY}
+EOF
+echo "  Written to /etc/default/crda"
+
 # --- WiFi configuration ---
 if [[ -n "$WIFI_SSID" ]]; then
     echo ""

--- a/scripts/build-image.sh
+++ b/scripts/build-image.sh
@@ -291,6 +291,25 @@ PI_HASH=$(openssl passwd -6 "$PI_PASSWORD")
 echo "pi:${PI_HASH}" > "${MOUNT_DIR}/boot/firmware/userconf.txt"
 echo "  Written to /boot/firmware/userconf.txt (pi:picketfencing)"
 
+# --- Network MTU for CGNAT ---
+# T-Mobile and other CGNAT providers have a path MTU of ~1424 but silently
+# drop oversized packets. TLS handshakes (1500+ bytes) fail without this.
+# MSS clamp alone doesn't help — the TLS ClientHello is a single segment.
+echo ""
+echo "=== Set network MTU to 1400 for CGNAT compatibility ==="
+mkdir -p "${MOUNT_DIR}/etc/networkd-dispatcher/routable.d"
+cat > "${MOUNT_DIR}/etc/networkd-dispatcher/routable.d/50-mtu-clamp" << 'MTUFIX'
+#!/bin/sh
+# Set MTU on all physical interfaces for CGNAT compatibility
+for dev in /sys/class/net/eth* /sys/class/net/wlan*; do
+    [ -e "$dev" ] || continue
+    iface=$(basename "$dev")
+    ip link set "$iface" mtu 1400 2>/dev/null || true
+done
+MTUFIX
+chmod +x "${MOUNT_DIR}/etc/networkd-dispatcher/routable.d/50-mtu-clamp"
+echo "  Written to /etc/networkd-dispatcher/routable.d/50-mtu-clamp"
+
 # --- WiFi regulatory domain ---
 # Without a country code, the Pi WiFi radio stays in passive-scan mode
 # and cannot connect to any network.

--- a/scripts/build-image.sh
+++ b/scripts/build-image.sh
@@ -154,6 +154,8 @@ fi
 # --- Copy to working file, decompress ---
 echo ""
 echo "=== Decompress ==="
+# Clean up any leftover work files from previous failed builds
+rm -f "$IMAGE_WORK" "$IMAGE_WORK.xz"
 echo "Copying to work image..."
 cp "$IMAGE_XZ" "$IMAGE_WORK.xz"
 echo "Decompressing..."

--- a/scripts/build-image.sh
+++ b/scripts/build-image.sh
@@ -26,7 +26,7 @@ IMAGE_DATE="2025-12-04"
 IMAGE_NAME="${IMAGE_DATE}-raspios-trixie-arm64-lite"
 IMAGE_URL="https://downloads.raspberrypi.com/raspios_lite_arm64/images/raspios_lite_arm64-${IMAGE_DATE}/${IMAGE_NAME}.img.xz"
 
-EXPAND_GB=3
+EXPAND_GB=4
 COMPRESS="${COMPRESS:-true}"
 
 BUILD_DIR="/build"

--- a/scripts/provision.sh
+++ b/scripts/provision.sh
@@ -180,8 +180,8 @@ Requires=docker.service
 [Service]
 Type=simple
 WorkingDirectory=/opt/openwebrx
-# First boot pulls the image (~1GB); subsequent boots skip if cached
-ExecStartPre=/usr/bin/docker compose pull
+# Load pre-saved image on first boot, then delete the tar to free ~1GB
+ExecStartPre=/bin/sh -c 'test -f /opt/openwebrx/image.tar && docker load < /opt/openwebrx/image.tar && rm -f /opt/openwebrx/image.tar || true'
 ExecStart=/usr/bin/docker compose up --remove-orphans
 ExecStop=/usr/bin/docker compose down
 Restart=always

--- a/scripts/provision.sh
+++ b/scripts/provision.sh
@@ -87,6 +87,31 @@ EOF
         /etc/systemd/system/multi-user.target.wants/tailscale-firstboot.service
 fi
 
+# --- Tailscale HTTPS cert for OpenWebRX+ ---
+# Generates a real Let's Encrypt cert via Tailscale on first boot.
+# Browsers require HTTPS for web audio — without this, no sound.
+cat > /etc/systemd/system/tailscale-cert.service << 'CERTSERVICE'
+[Unit]
+Description=Generate Tailscale HTTPS certificate for OpenWebRX+
+After=tailscale-firstboot.service tailscaled.service
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+# Wait for Tailscale to be fully connected
+ExecStartPre=/bin/sh -c 'until tailscale status --json | grep -q "BackendState.*Running"; do sleep 2; done'
+ExecStart=/bin/sh -c 'FQDN=$(tailscale status --self --json | python3 -c "import sys,json; print(json.load(sys.stdin)[\"Self\"][\"DNSName\"].rstrip(\".\"))") && tailscale cert --cert-file /opt/openwebrx/etc/openwebrx/cert.pem --key-file /opt/openwebrx/etc/openwebrx/key.pem "$FQDN"'
+ExecStartPost=/usr/bin/docker restart openwebrx 2>/dev/null
+ExecStartPost=/bin/systemctl disable tailscale-cert.service
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target
+CERTSERVICE
+systemctl enable tailscale-cert.service || ln -sf \
+    /etc/systemd/system/tailscale-cert.service \
+    /etc/systemd/system/multi-user.target.wants/tailscale-cert.service
+
 # --- OpenWebRX+ (Docker) ---
 # The OpenWebRX+ PPA requires Python < 3.12 (python3-csdr dependency), but
 # Trixie ships Python 3.13. Instead of native install, we run OpenWebRX+ as a

--- a/scripts/provision.sh
+++ b/scripts/provision.sh
@@ -181,7 +181,7 @@ Requires=docker.service
 Type=simple
 WorkingDirectory=/opt/openwebrx
 # Load pre-saved image on first boot, then delete the tar to free ~1GB
-ExecStartPre=/bin/sh -c 'test -f /opt/openwebrx/image.tar && docker load < /opt/openwebrx/image.tar && rm -f /opt/openwebrx/image.tar || true'
+ExecStartPre=/bin/sh -c 'test -f /opt/openwebrx/openwebrxplus-softmbe-arm64.tar && docker load < /opt/openwebrx/openwebrxplus-softmbe-arm64.tar && rm -f /opt/openwebrx/openwebrxplus-softmbe-arm64.tar || true'
 ExecStart=/usr/bin/docker compose up --remove-orphans
 ExecStop=/usr/bin/docker compose down
 Restart=always

--- a/scripts/provision.sh
+++ b/scripts/provision.sh
@@ -63,6 +63,19 @@ systemctl enable ssh.service || ln -sf \
 # Set pi user password (matches userconf.txt on boot partition)
 echo "pi:picketfencing" | chpasswd
 
+# --- TCP MSS clamp for CGNAT environments ---
+# T-Mobile home internet and other CGNAT providers have reduced path MTU (~1424)
+# but silently drop oversized packets without sending ICMP "too big" responses.
+# This causes TLS handshakes (including Tailscale control plane) to hang.
+# Clamping TCP MSS to PMTU lets the kernel negotiate correct segment sizes.
+echo "=== Configure TCP MSS clamp ==="
+cat > /etc/networkd-dispatcher/routable.d/50-mss-clamp << 'MSSCLAMP'
+#!/bin/sh
+iptables -t mangle -C POSTROUTING -p tcp --tcp-flags SYN,RST SYN -o "$IFACE" -j TCPMSS --clamp-mss-to-pmtu 2>/dev/null || \
+iptables -t mangle -A POSTROUTING -p tcp --tcp-flags SYN,RST SYN -o "$IFACE" -j TCPMSS --clamp-mss-to-pmtu
+MSSCLAMP
+chmod +x /etc/networkd-dispatcher/routable.d/50-mss-clamp
+
 # --- DVB kernel module blacklist ---
 # DVB modules claim the RTL-SDR chip at boot; blacklisting hands it to rtl-sdr.
 echo "=== Install DVB blacklist ==="
@@ -190,6 +203,8 @@ Requires=docker.service
 [Service]
 Type=simple
 WorkingDirectory=/opt/openwebrx
+# docker load of 1.1GB tar on SD card can take >90s; allow 5 minutes
+TimeoutStartSec=300
 # Load pre-saved image on first boot, then delete the tar to free ~1GB
 ExecStartPre=/bin/sh -c 'test -f /opt/openwebrx/openwebrxplus-softmbe-arm64.tar && docker load < /opt/openwebrx/openwebrxplus-softmbe-arm64.tar && rm -f /opt/openwebrx/openwebrxplus-softmbe-arm64.tar || true'
 ExecStart=/usr/bin/docker compose up --remove-orphans

--- a/scripts/provision.sh
+++ b/scripts/provision.sh
@@ -7,6 +7,7 @@
 #   DEBIAN_FRONTEND      — set to noninteractive
 #   PATH                 — /usr/sbin:/usr/bin:/sbin:/bin
 #   TAILSCALE_AUTHKEY    — optional; if set, creates a first-boot auth service
+#   OPENWEBRX_ADMIN_PASSWORD — optional; if set, creates an admin user for the web UI
 
 set -euo pipefail
 export DEBIAN_FRONTEND=noninteractive
@@ -85,6 +86,56 @@ EOF
         /etc/systemd/system/tailscale-firstboot.service \
         /etc/systemd/system/multi-user.target.wants/tailscale-firstboot.service
 fi
+
+# --- OpenWebRX+ ---
+# The PPA only has bookworm packages; they work on Trixie.
+echo "=== Install OpenWebRX+ ==="
+apt-get install -y gnupg
+curl -fsSL https://luarvique.github.io/ppa/openwebrx-plus.gpg \
+    | gpg --yes --dearmor -o /etc/apt/trusted.gpg.d/openwebrx-plus.gpg
+echo "deb [signed-by=/etc/apt/trusted.gpg.d/openwebrx-plus.gpg] https://luarvique.github.io/ppa/bookworm ./" \
+    > /etc/apt/sources.list.d/openwebrx-plus.list
+apt-get update
+apt-get install -y openwebrx
+
+# --- Digital mode decoders ---
+echo "=== Install digital mode decoders ==="
+apt-get install -y \
+    codec2 \
+    direwolf \
+    wsjtx \
+    m17-demod \
+    multimon-ng
+
+# --- Deploy OpenWebRX+ config ---
+echo "=== Deploy OpenWebRX+ config ==="
+cp /opt/provision/config/openwebrx/openwebrx.conf /etc/openwebrx/openwebrx.conf
+
+# Settings (SDR profiles, receiver info) go to data directory
+mkdir -p /var/lib/openwebrx
+cp /opt/provision/config/openwebrx/settings.json /var/lib/openwebrx/settings.json
+
+# Frequency bookmarks
+if [[ -d /opt/provision/config/openwebrx/bookmarks.d ]]; then
+    mkdir -p /etc/openwebrx/bookmarks.d
+    cp /opt/provision/config/openwebrx/bookmarks.d/*.json /etc/openwebrx/bookmarks.d/
+fi
+
+# Fix ownership — openwebrx user is created by the package install
+chown -R openwebrx:openwebrx /var/lib/openwebrx/
+
+# --- OpenWebRX admin user ---
+OPENWEBRX_ADMIN_PASSWORD="${OPENWEBRX_ADMIN_PASSWORD:-}"
+if [[ -n "$OPENWEBRX_ADMIN_PASSWORD" ]]; then
+    echo "=== Create OpenWebRX admin user ==="
+    echo "$OPENWEBRX_ADMIN_PASSWORD" | openwebrx admin adduser --noninteractive admin
+fi
+
+# Enable the service at boot
+echo "=== Enable OpenWebRX service ==="
+systemctl enable openwebrx.service || ln -sf \
+    /lib/systemd/system/openwebrx.service \
+    /etc/systemd/system/multi-user.target.wants/openwebrx.service
 
 # --- Deploy test scripts ---
 echo "=== Deploy test scripts ==="

--- a/scripts/provision.sh
+++ b/scripts/provision.sh
@@ -53,6 +53,16 @@ apt-get install -y \
     soapysdr-module-rtlsdr \
     python3-soapysdr
 
+# --- Enable SSH ---
+echo "=== Enable SSH ==="
+apt-get install -y openssh-server
+systemctl enable ssh.service || ln -sf \
+    /lib/systemd/system/ssh.service \
+    /etc/systemd/system/multi-user.target.wants/ssh.service
+
+# Set pi user password (matches userconf.txt on boot partition)
+echo "pi:picketfencing" | chpasswd
+
 # --- DVB kernel module blacklist ---
 # DVB modules claim the RTL-SDR chip at boot; blacklisting hands it to rtl-sdr.
 echo "=== Install DVB blacklist ==="

--- a/scripts/provision.sh
+++ b/scripts/provision.sh
@@ -87,54 +87,86 @@ EOF
         /etc/systemd/system/multi-user.target.wants/tailscale-firstboot.service
 fi
 
-# --- OpenWebRX+ ---
-# The PPA only has bookworm packages; they work on Trixie.
-echo "=== Install OpenWebRX+ ==="
-apt-get install -y gnupg
-curl -fsSL https://luarvique.github.io/ppa/openwebrx-plus.gpg \
-    | gpg --yes --dearmor -o /etc/apt/trusted.gpg.d/openwebrx-plus.gpg
-echo "deb [signed-by=/etc/apt/trusted.gpg.d/openwebrx-plus.gpg] https://luarvique.github.io/ppa/bookworm ./" \
-    > /etc/apt/sources.list.d/openwebrx-plus.list
+# --- OpenWebRX+ (Docker) ---
+# The OpenWebRX+ PPA requires Python < 3.12 (python3-csdr dependency), but
+# Trixie ships Python 3.13. Instead of native install, we run OpenWebRX+ as a
+# Docker container on the Pi. The slechev/openwebrxplus-softmbe image bundles
+# all decoders (DMR, D-STAR, NXDN, P25, M17, WSJTX, APRS, etc.) for arm64.
+echo "=== Install Docker for OpenWebRX+ ==="
+# Install Docker from official repo — can't run the daemon in chroot,
+# but we can install packages. The container image pulls on first boot.
+apt-get install -y ca-certificates curl
+install -m 0755 -d /etc/apt/keyrings
+curl -fsSL https://download.docker.com/linux/debian/gpg -o /etc/apt/keyrings/docker.asc
+chmod a+r /etc/apt/keyrings/docker.asc
+echo "deb [arch=arm64 signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/debian trixie stable" \
+    > /etc/apt/sources.list.d/docker.list
 apt-get update
-apt-get install -y openwebrx
+apt-get install -y docker-ce docker-ce-cli containerd.io docker-compose-plugin
+usermod -aG docker pi || true
 
-# --- Digital mode decoders ---
-echo "=== Install digital mode decoders ==="
-apt-get install -y \
-    codec2 \
-    direwolf \
-    wsjtx \
-    m17-demod \
-    multimon-ng
-
-# --- Deploy OpenWebRX+ config ---
+# Deploy OpenWebRX+ config to host paths that get volume-mounted into the container
 echo "=== Deploy OpenWebRX+ config ==="
-cp /opt/provision/config/openwebrx/openwebrx.conf /etc/openwebrx/openwebrx.conf
+mkdir -p /opt/openwebrx/etc/openwebrx /opt/openwebrx/var
+cp /opt/provision/config/openwebrx/openwebrx.conf /opt/openwebrx/etc/openwebrx/openwebrx.conf
+cp /opt/provision/config/openwebrx/settings.json /opt/openwebrx/var/settings.json
 
-# Settings (SDR profiles, receiver info) go to data directory
-mkdir -p /var/lib/openwebrx
-cp /opt/provision/config/openwebrx/settings.json /var/lib/openwebrx/settings.json
-
-# Frequency bookmarks
 if [[ -d /opt/provision/config/openwebrx/bookmarks.d ]]; then
-    mkdir -p /etc/openwebrx/bookmarks.d
-    cp /opt/provision/config/openwebrx/bookmarks.d/*.json /etc/openwebrx/bookmarks.d/
+    mkdir -p /opt/openwebrx/etc/openwebrx/bookmarks.d
+    cp /opt/provision/config/openwebrx/bookmarks.d/*.json /opt/openwebrx/etc/openwebrx/bookmarks.d/
 fi
 
-# Fix ownership — openwebrx user is created by the package install
-chown -R openwebrx:openwebrx /var/lib/openwebrx/
-
-# --- OpenWebRX admin user ---
+# Create docker-compose.yml for OpenWebRX+
 OPENWEBRX_ADMIN_PASSWORD="${OPENWEBRX_ADMIN_PASSWORD:-}"
+cat > /opt/openwebrx/docker-compose.yml << 'COMPOSE'
+services:
+  openwebrx:
+    image: slechev/openwebrxplus-softmbe:latest
+    container_name: openwebrx
+    restart: unless-stopped
+    ports:
+      - "8073:8073"
+    devices:
+      - /dev/bus/usb:/dev/bus/usb
+    volumes:
+      - /opt/openwebrx/etc/openwebrx:/etc/openwebrx
+      - /opt/openwebrx/var:/var/lib/openwebrx
+    tmpfs:
+      - /tmp
+COMPOSE
+
+# Add admin user env vars if password was provided
 if [[ -n "$OPENWEBRX_ADMIN_PASSWORD" ]]; then
-    echo "=== Create OpenWebRX admin user ==="
-    echo "$OPENWEBRX_ADMIN_PASSWORD" | openwebrx admin adduser --noninteractive admin
+    cat >> /opt/openwebrx/docker-compose.yml << EOF
+    environment:
+      - OPENWEBRX_ADMIN_USER=admin
+      - OPENWEBRX_ADMIN_PASSWORD=${OPENWEBRX_ADMIN_PASSWORD}
+EOF
 fi
 
-# Enable the service at boot
-echo "=== Enable OpenWebRX service ==="
+# Create systemd service to start OpenWebRX+ container on boot
+cat > /etc/systemd/system/openwebrx.service << 'SERVICE'
+[Unit]
+Description=OpenWebRX+ Web SDR Receiver
+After=network-online.target docker.service
+Wants=network-online.target
+Requires=docker.service
+
+[Service]
+Type=simple
+WorkingDirectory=/opt/openwebrx
+# First boot pulls the image (~1GB); subsequent boots skip if cached
+ExecStartPre=/usr/bin/docker compose pull
+ExecStart=/usr/bin/docker compose up --remove-orphans
+ExecStop=/usr/bin/docker compose down
+Restart=always
+RestartSec=10
+
+[Install]
+WantedBy=multi-user.target
+SERVICE
 systemctl enable openwebrx.service || ln -sf \
-    /lib/systemd/system/openwebrx.service \
+    /etc/systemd/system/openwebrx.service \
     /etc/systemd/system/multi-user.target.wants/openwebrx.service
 
 # --- Deploy test scripts ---

--- a/scripts/test-entrypoint.sh
+++ b/scripts/test-entrypoint.sh
@@ -1,0 +1,92 @@
+#!/bin/sh
+# test-entrypoint.sh — simulates Pi first boot inside a test container
+# Starts Tailscale, generates HTTPS cert, deploys OpenWebRX+ config, starts SSH.
+set -e
+
+echo "=== Pi SDR Test Container ==="
+
+# --- Deploy OpenWebRX+ config to shared volume ---
+echo "Deploying OpenWebRX+ config..."
+cp /config-src/openwebrx.conf /owrx-etc/openwebrx.conf
+if [ -d /config-src/bookmarks.d ]; then
+    cp -r /config-src/bookmarks.d /owrx-etc/bookmarks.d
+fi
+
+# --- Start Tailscale ---
+echo "Starting tailscaled..."
+tailscaled --state=/var/lib/tailscale/tailscaled.state &
+sleep 2
+
+echo "Authenticating with Tailscale..."
+if [ -n "$TS_AUTHKEY" ]; then
+    tailscale up --authkey="$TS_AUTHKEY" --hostname="${TS_HOSTNAME:-pi-sdr-test}"
+else
+    echo "ERROR: TS_AUTHKEY not set"
+    exit 1
+fi
+
+# --- Get identity ---
+echo ""
+echo "=== Tailscale Status ==="
+tailscale status
+FQDN=$(tailscale status --self --json | grep -m1 '"DNSName"' | sed 's/.*"DNSName": *"\([^"]*\)".*/\1/' | sed 's/\.$//')
+TS_IP=$(tailscale ip -4)
+echo ""
+echo "Tailscale FQDN: $FQDN"
+echo "Tailscale IP:   $TS_IP"
+
+# --- Generate HTTPS cert into the shared OpenWebRX config dir ---
+echo ""
+echo "=== Generating HTTPS cert ==="
+CERT_OK=false
+if [ -n "$FQDN" ]; then
+    # Retry up to 3 times — ACME authorization can lag on new hostnames
+    for attempt in 1 2 3; do
+        if tailscale cert --cert-file /owrx-etc/cert.pem --key-file /owrx-etc/key.pem "$FQDN" 2>&1; then
+            chmod 644 /owrx-etc/cert.pem /owrx-etc/key.pem
+            echo "HTTPS cert generated for $FQDN"
+            CERT_OK=true
+            break
+        fi
+        echo "  Cert attempt $attempt failed, retrying in 5s..."
+        sleep 5
+    done
+fi
+if [ "$CERT_OK" = false ]; then
+    echo "WARNING: HTTPS cert generation failed — OpenWebRX+ will use HTTP"
+fi
+
+# --- Set up SSH ---
+if command -v sshd >/dev/null 2>&1 || apk add openssh 2>/dev/null; then
+    echo ""
+    echo "=== Setting up SSH ==="
+    adduser -D -s /bin/sh pi 2>/dev/null || true
+    echo "pi:picketfencing" | chpasswd 2>/dev/null || true
+    # Alpine: sshd needs shadow group access to verify passwords
+    addgroup sshd shadow 2>/dev/null || true
+    ssh-keygen -A 2>/dev/null || true
+    mkdir -p /etc/ssh
+    cat > /etc/ssh/sshd_config <<SSHD
+Port 22
+PermitRootLogin no
+PasswordAuthentication yes
+SSHD
+    /usr/sbin/sshd -e 2>&1 &
+    echo "SSH ready"
+fi
+
+# --- Summary ---
+echo ""
+echo "========================================="
+echo "  Pi SDR Test Container Ready"
+echo "========================================="
+echo ""
+echo "  OpenWebRX+: https://$FQDN:8073"
+echo "  SSH:        ssh pi@$FQDN"
+echo "  Password:   picketfencing"
+echo "  Tailscale:  $TS_IP"
+echo ""
+echo "========================================="
+
+# Keep running
+tail -f /dev/null


### PR DESCRIPTION
## Summary

- Run OpenWebRX+ as a Docker container (`slechev/openwebrxplus-softmbe`) — native apt install fails because Trixie ships Python 3.13 but `python3-csdr` requires < 3.12
- Pre-pull OpenWebRX+ Docker image (arm64, ~1.1 GB) into Pi filesystem for offline first boot
- Pre-configure RTL-SDR Blog V4 with 8 band profiles (FM, NOAA, 2m, 70cm, GMRS, airband, marine, APRS)
- Curated frequency bookmarks for US radio services (public FCC/ITU allocations only)
- Auto HTTPS cert via Tailscale on first boot (browsers require HTTPS for web audio)
- Enable SSH with pi user and password during build (no manual patching needed)
- TCP MSS clamp for CGNAT environments (T-Mobile path MTU ~1424 breaks TLS handshakes)
- Extended systemd timeout for docker load on SD card (1.1 GB tar takes >90s)
- Docker-based E2E test (`docker-compose.test.yml`) for validating Tailscale, SSH, and OpenWebRX+

## Validated on Pi 5 hardware

- SSH via Tailscale FQDN (`raspberrypi.wirehair-yo.ts.net`) and LAN
- Tailscale direct peer connection (3ms via LAN)
- HTTPS cert auto-generated via Tailscale (Let's Encrypt)
- OpenWebRX+ waterfall + audio working at `https://raspberrypi.wirehair-yo.ts.net:8073`
- Offline Docker image load on first boot (after TimeoutStartSec fix)
- Survives reboot — all services come back up cleanly

## Test plan

- [x] Full image rebuild with SSH and SSL changes baked in
- [x] E2E test in Docker: Tailscale auth, HTTPS cert, SSH, OpenWebRX+ audio
- [x] Flash to Pi 5 and verify first-boot sequence
- [x] Verify reboot stability
- [ ] Clean up stale Tailscale nodes from admin console

🤖 Generated with [Claude Code](https://claude.com/claude-code)